### PR TITLE
Fix Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A: Please open an issue!
 
 **Q: Will you accept a pull request?**
 
-A: We haven't worked out out pull requests should work for a public roadmap page, but we will take all PRs very seriously and review for inclusion. Read about [contributing](/CONTRIBUTING.md).
+A: We haven't worked out how pull requests should work for a public roadmap page, but we will take all PRs very seriously and review for inclusion. Read about [contributing](/CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
*Description of changes:*
"out" => "how"

I won't be even the slightest upset if you decide to decline this PR and fix the typo yourself the next time you update the docs. I did this entirely out of the novelty of submitting a PR on the one line in the entire repository that mentions how PR's haven't yet been fleshed out. :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
