### PR TITLE
Adding "Principles" to the Containers Roadmap

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -1,0 +1,22 @@
+# Principles
+
+These are the principles that embody the culture of the container services organization.  They build on the [Amazon Leadership Principles](https://www.amazon.jobs/en/principles).
+
+## People
+
+* we invest in people through a focus on individual development, career progression, mentorship, and active sponsorship;
+* we embrace diversity and inclusiveness recognizing that innovation is fueled by challenging accepted norms, driving for understanding, and broadening perspective;
+* we empower the voice of the individual by creating an environment where everyone can speak up, where leaders listen, actively address, and follow through on feedback;
+
+## Priorities
+
+* we emphasize service reliability as the primary mechanism for earning and retaining customer trust, we factor operational sustainability into our development practices;
+* we consider user experience to be our top feature, understanding that simplicity is powerful, and we are confident in being opinionated;
+* we focus on the long-term, and build a roadmap that blends large and small improvements, preferring steady and consistent releases;
+* we deliver on the right priorities because we work backwards from our customers, have the right mechanisms for measuring value, and have the ability to respond quickly to shifts in customer expectations.
+
+## Product
+
+* we are open and transparent in sharing the product vision and direction with the team and customers, identifying where we are succeeding and where we can improve, recognizing that sharing this information accurately advises us on how we get better;
+* we encourage and enable individuals to interact directly with customers as a means toward building awareness, understanding, and customer empathy;
+* we embrace open source where possible as a mechanism to build better software, to give our customers insight into our designs, and because we don't assume that we always have the best answers.


### PR DESCRIPTION
These are the principles by which we run the containers organization.
They build on the Amazon Leadership Principles.

*Issue #, if available:*

*Description of changes:* I am proposing we add a section to the Containers Roadmap that outline the principles by which we run the container services organization.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
