### PR TITLE
Add task IAM roles to FireLens AWS examples

### DIFF
--- a/preview-programs/firelens/cloudwatch_task_definition.json
+++ b/preview-programs/firelens/cloudwatch_task_definition.json
@@ -1,5 +1,6 @@
 {
 	"family": "firelens-example-cloudwatch",
+	"taskRoleArn": "arn:aws:iam::XXXXXXXXXXXX:role/ecs_task_iam_role",
 	"containerDefinitions": [
 		{
 			"essential": true,

--- a/preview-programs/firelens/firehose_task_definition.json
+++ b/preview-programs/firelens/firehose_task_definition.json
@@ -1,5 +1,6 @@
 {
 	"family": "firelens-example-firehose",
+	"taskRoleArn": "arn:aws:iam::XXXXXXXXXXXX:role/ecs_task_iam_role",
 	"containerDefinitions": [
 		{
 			"essential": true,


### PR DESCRIPTION
Using Task IAM Roles is a best practice that the examples should demonstrate. Also, on Fargate, a Task IAM Role is required if the log destination is an AWS Service.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
