### PR TITLE
Re-add & fix ECR Image links

### DIFF
--- a/preview-programs/firelens/README.md
+++ b/preview-programs/firelens/README.md
@@ -78,7 +78,34 @@ When enabled, a log event will look like the following:
 
 We recommend that you use Fluent Bit as your log router because its resource utilization is significantly lower than Fluentd. AWS provides a Fluent Bit image with plugins for [CloudWatch Logs](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit) and [Kinesis Firehose](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit).
 
-This image is available on [Docker Hub](https://hub.docker.com/r/amazon/aws-for-fluent-bit).
+This image is available on [Docker Hub](https://hub.docker.com/r/amazon/aws-for-fluent-bit), however, we recommend that you use the regionalized [Amazon ECR](https://aws.amazon.com/ecr/) image repositories because they provide higher availability.
+
+
+| Region         | Registry ID  | Full Image Names                                                          |
+|----------------|--------------|-------------------------------------------------------------------------|
+| us-east-1      | 906394416424 | 906394416424.dkr.ecr.us-east-1.amazonaws.com/aws-for-fluent-bit:latest      |
+| eu-west-1      | 906394416424 | 906394416424.dkr.ecr.eu-west-1.amazonaws.com/aws-for-fluent-bit:latest      |
+| us-west-1      | 906394416424 | 906394416424.dkr.ecr.us-west-1.amazonaws.com/aws-for-fluent-bit:latest      |
+| ap-southeast-1 | 906394416424 | 906394416424.dkr.ecr.ap-southeast-1.amazonaws.com/aws-for-fluent-bit:latest |
+| ap-northeast-1 | 906394416424 | 906394416424.dkr.ecr.ap-northeast-1.amazonaws.com/aws-for-fluent-bit:latest |
+| us-west-2      | 906394416424 | 906394416424.dkr.ecr.us-west-2.amazonaws.com/aws-for-fluent-bit:latest      |
+| sa-east-1      | 906394416424 | 906394416424.dkr.ecr.sa-east-1.amazonaws.com/aws-for-fluent-bit:latest      |
+| ap-southeast-2 | 906394416424 | 906394416424.dkr.ecr.ap-southeast-2.amazonaws.com/aws-for-fluent-bit:latest |
+| eu-central-1   | 906394416424 | 906394416424.dkr.ecr.eu-central-1.amazonaws.com/aws-for-fluent-bit:latest   |
+| ap-northeast-2 | 906394416424 | 906394416424.dkr.ecr.ap-northeast-2.amazonaws.com/aws-for-fluent-bit:latest |
+| ap-south-1     | 906394416424 | 906394416424.dkr.ecr.ap-south-1.amazonaws.com/aws-for-fluent-bit:latest     |
+| us-east-2      | 906394416424 | 906394416424.dkr.ecr.us-east-2.amazonaws.com/aws-for-fluent-bit:latest      |
+| ca-central-1   | 906394416424 | 906394416424.dkr.ecr.ca-central-1.amazonaws.com/aws-for-fluent-bit:latest   |
+| eu-west-2      | 906394416424 | 906394416424.dkr.ecr.eu-west-2.amazonaws.com/aws-for-fluent-bit:latest      |
+| eu-west-3      | 906394416424 | 906394416424.dkr.ecr.eu-west-3.amazonaws.com/aws-for-fluent-bit:latest      |
+| ap-northeast-3 | 906394416424 | 906394416424.dkr.ecr.ap-northeast-3.amazonaws.com/aws-for-fluent-bit:latest |
+| eu-north-1     | 906394416424 | 906394416424.dkr.ecr.eu-north-1.amazonaws.com/aws-for-fluent-bit:latest     |
+| ap-east-1      | 449074385750 | 449074385750.dkr.ecr.ap-east-1.amazonaws.com/aws-for-fluent-bit:latest      |
+| cn-north-1     | 128054284489 | 128054284489.dkr.ecr.cn-north-1.amazonaws.com.cn/aws-for-fluent-bit:latest     |
+| cn-northwest-1 | 128054284489 | 128054284489.dkr.ecr.cn-northwest-1.amazonaws.com.cn/aws-for-fluent-bit:latest |
+| us-gov-east-1  | 161423150738 | 161423150738.dkr.ecr.us-gov-east-1.amazonaws.com/aws-for-fluent-bit:latest  |
+| us-gov-west-1  | 161423150738 | 161423150738.dkr.ecr.us-gov-west-1.amazonaws.com/aws-for-fluent-bit:latest  |
+
 
 ## FireLens Task Definitions
 


### PR DESCRIPTION
There were no problems with the ECR repos. The URIs in the docs were just invalid, they were missing the service name, "ecr".

Old Wrong link: 906394416424.dkr.us-east-1.amazonaws.com/aws-for-fluent-bit:latest 
Fixed new link: 906394416424.dkr.ecr.us-east-1.amazonaws.com/aws-for-fluent-bit:latest


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
