### PR TITLE
Update a1 image preview instruction to use latest images.

### DIFF
--- a/preview-programs/eks-ec2-a1-preview/amazon-eks-arm-nodegroup.yaml
+++ b/preview-programs/eks-ec2-a1-preview/amazon-eks-arm-nodegroup.yaml
@@ -23,6 +23,7 @@ Parameters:
       - a1.xlarge
       - a1.2xlarge
       - a1.4xlarge
+      - a1.metal
 
   NodeAutoScalingGroupMinSize:
     Description: Minimum size of Node Group ASG.
@@ -51,7 +52,6 @@ Parameters:
   BootstrapArguments:
     Description: Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami
     Type: String
-    Default: "--pause-container-account 940911992744"
 
   NodeGroupName:
     Description: Unique identifier for the Node Group.

--- a/preview-programs/eks-ec2-a1-preview/aws-k8s-cni-arm64.yaml
+++ b/preview-programs/eks-ec2-a1-preview/aws-k8s-cni-arm64.yaml
@@ -1,130 +1,127 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: aws-node-arm
+  name: aws-node
 rules:
-- apiGroups:
-  - crd.k8s.amazonaws.com
-  resources:
-  - "*"
-  - namespaces
-  verbs:
-  - "*"
-- apiGroups: [""]
-  resources:
-  - pods
-  - nodes
-  - namespaces
-  verbs: ["list", "watch", "get"]
-- apiGroups: ["extensions"]
-  resources:
-  - daemonsets
-  verbs: ["list", "watch"]
+  - apiGroups:
+      - crd.k8s.amazonaws.com
+    resources:
+      - "*"
+      - namespaces
+    verbs:
+      - "*"
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs: ["list", "watch", "get"]
+  - apiGroups: ["extensions"]
+    resources:
+      - daemonsets
+    verbs: ["list", "watch"]
+
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: aws-node-arm
+  name: aws-node
   namespace: kube-system
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: aws-node-arm
+  name: aws-node
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: aws-node-arm
+  name: aws-node
 subjects:
-- kind: ServiceAccount
-  name: aws-node-arm
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: aws-node
+    namespace: kube-system
+
 ---
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
-  name: aws-node-arm
+  name: aws-node
   namespace: kube-system
   labels:
-    k8s-app: aws-node-arm
+    k8s-app: aws-node
 spec:
   updateStrategy:
     type: RollingUpdate
   selector:
     matchLabels:
-      k8s-app: aws-node-arm
+      k8s-app: aws-node
   template:
     metadata:
       labels:
-        k8s-app: aws-node-arm
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
+        k8s-app: aws-node
     spec:
+      priorityClassName: system-node-critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: "beta.kubernetes.io/os"
-                operator: In
-                values:
-                - linux
-              - key: "beta.kubernetes.io/arch"
-                operator: In
-                values:
-                - arm64
-      serviceAccountName: aws-node-arm
+              - matchExpressions:
+                  - key: "kubernetes.io/os"
+                    operator: In
+                    values:
+                      - linux
+                  - key: "kubernetes.io/arch"
+                    operator: In
+                    values:
+                      - arm64
+      serviceAccountName: aws-node
       hostNetwork: true
       tolerations:
-      - operator: Exists
+        - operator: Exists
       containers:
-      - image: 940911992744.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-arm64:v1.3.3
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 61678
-          name: metrics
-        name: aws-node-arm
-        env:
-          - name: AWS_VPC_K8S_CNI_LOGLEVEL
-            value: DEBUG
-          - name: MY_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: WATCH_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        resources:
-          requests:
-            cpu: 10m
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /host/opt/cni/bin
-          name: cni-bin-dir
-        - mountPath: /host/etc/cni/net.d
-          name: cni-net-dir
-        - mountPath: /host/var/log
-          name: log-dir
-        - mountPath: /var/run/docker.sock
-          name: dockersock
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-arm64:v1.5.3
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 61678
+              name: metrics
+          name: aws-node
+          env:
+            - name: AWS_VPC_K8S_CNI_LOGLEVEL
+              value: DEBUG
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: 10m
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+            - mountPath: /host/var/log
+              name: log-dir
+            - mountPath: /var/run/docker.sock
+              name: dockersock
       volumes:
-      - name: cni-bin-dir
-        hostPath:
-          path: /opt/cni/bin
-      - name: cni-net-dir
-        hostPath:
-          path: /etc/cni/net.d
-      - name: log-dir
-        hostPath:
-          path: /var/log
-      - name: dockersock
-        hostPath:
-          path: /var/run/docker.sock
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        - name: log-dir
+          hostPath:
+            path: /var/log
+        - name: dockersock
+          hostPath:
+            path: /var/run/docker.sock
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -133,7 +130,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   names:
     plural: eniconfigs
     singular: eniconfig

--- a/preview-programs/eks-ec2-a1-preview/cni-metrics-helper-arm64.yaml
+++ b/preview-programs/eks-ec2-a1-preview/cni-metrics-helper-arm64.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cni-metrics-helper
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - pods
+      - pods/proxy
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs: ["list", "watch", "get"]
+  - apiGroups: ["extensions"]
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs: ["list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+    verbs: ["list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - cronjobs
+      - jobs
+    verbs: ["list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cni-metrics-helper
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cni-metrics-helper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cni-metrics-helper
+subjects:
+  - kind: ServiceAccount
+    name: cni-metrics-helper
+    namespace: kube-system
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: cni-metrics-helper
+  namespace: kube-system
+  labels:
+    k8s-app: cni-metrics-helper
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cni-metrics-helper
+  template:
+    metadata:
+      labels:
+        k8s-app: cni-metrics-helper
+    spec:
+      serviceAccountName: cni-metrics-helper
+      containers:
+      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper-arm64:v1.5.3
+        imagePullPolicy: Always
+        name: cni-metrics-helper
+        env:
+          - name: USE_CLOUDWATCH
+            value: "true"


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

*Issue #, if available:* #264

*Description of changes:*
This PR updates the arm64 images for EKS worker nodes. The changes include:
* Update the AWS CNI arm64 build to v1.5.3.
* Added a `cni-metrics-helper` image.
* Published new arm64 worker AMIs for Kubernetes v1.13 and v1.14.
* Updated the instructions in the README.
* The guestbook-go example does not work on ARM, replaced that section.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
