### PR TITLE
Link to Elastic Beanstalk public roadmap in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Knowing about our upcoming products and priorities helps our customers plan. Thi
 **Other AWS Public Roadmaps**
 * [AWS App Mesh](https://github.com/aws/aws-app-mesh-roadmap)
 * [CloudFormation coverage](https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap)
+* [AWS Elastic Beanstalk](https://github.com/aws/elastic-beanstalk-roadmap)
 
 ## Developer Preview Programs
 We now have information for developer preview programs within this repository. Issues tagged [Developer Preview](https://github.com/aws/containers-roadmap/labels/Developer%20Preview) on the public roadmap are active preview programs.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

*Issue #, if available:*

*Description of changes:*

AWS Elastic Beanstalk recently also launched a [public roadmap](https://github.com/aws/elastic-beanstalk-roadmap) of its own. This PR includes a link to it on the "Other AWS Public Roadmaps" of the README.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
