### PR TITLE
ARM preview support for K8 1.15

### DIFF
--- a/preview-programs/eks-arm-preview/amazon-eks-arm-nodegroup.yaml
+++ b/preview-programs/eks-arm-preview/amazon-eks-arm-nodegroup.yaml
@@ -10,10 +10,11 @@ Parameters:
 
   KubernetesVersion:
     Type: String
-    Default: '1.14'
+    Default: '1.15'
     AllowedValues:
       - '1.13'
       - '1.14'
+      - '1.15'
 
   NodeInstanceType:
     Description: EC2 instance type for the node instances
@@ -26,6 +27,14 @@ Parameters:
       - a1.xlarge
       - a1.2xlarge
       - a1.4xlarge
+      - m6g.medium
+      - m6g.large
+      - m6g.xlarge
+      - m6g.2xlarge
+      - m6g.4xlarge
+      - m6g.8xlarge
+      - m6g.12xlarge
+      - m6g.16xlarge
 
   NodeAutoScalingGroupMinSize:
     Description: Minimum size of Node Group ASG.
@@ -82,6 +91,17 @@ Parameters:
     Type : 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
     Default: /aws/service/eks/optimized-ami/1.14/amazon-linux-2-arm64/recommended/image_id
 
+  NodeImageAMI115:
+    Description: The SSM parameter that contains the Amazon Machine Image (AMI) ID for Kubernetes 1.15 nodes.
+    Type : 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: /aws/service/eks/optimized-ami/1.15/amazon-linux-2-arm64/recommended/image_id
+
+Mappings:
+  PartitionMap:
+    aws:
+      EC2ServicePrincipal: "ec2.amazonaws.com"
+    aws-cn:
+      EC2ServicePrincipal: "ec2.amazonaws.com.cn"
 
 Metadata:
 
@@ -115,10 +135,12 @@ Metadata:
         Parameters:
           - NodeImageAMI113
           - NodeImageAMI114
+          - NodeImageAMI115
 
 Conditions:
   Kubernetes113: !Equals [!Ref KubernetesVersion, '1.13']
   Kubernetes114: !Equals [!Ref KubernetesVersion, '1.14']
+  Kubernetes115: !Equals [!Ref KubernetesVersion, '1.15']
 
 Resources:
 
@@ -137,13 +159,14 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: ec2.amazonaws.com
+              Service:
+                - !FindInMap [PartitionMap, !Ref "AWS::Partition", EC2ServicePrincipal]
             Action: sts:AssumeRole
       Path: "/"
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
-        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 
   NodeSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -244,13 +267,13 @@ Resources:
   NodeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      AssociatePublicIpAddress: true
       IamInstanceProfile: !Ref NodeInstanceProfile
       ImageId:
         Fn::Join:
           - ''
           - - !If [ Kubernetes114, !Ref NodeImageAMI114, '' ]
             - !If [ Kubernetes113, !Ref NodeImageAMI113, '' ]
+            - !If [ Kubernetes115, !Ref NodeImageAMI115, '' ]
       InstanceType: !Ref NodeInstanceType
       KeyName: !Ref KeyName
       SecurityGroups:

--- a/preview-programs/eks-arm-preview/kube-proxy-arm-1.15.yaml
+++ b/preview-programs/eks-arm-preview/kube-proxy-arm-1.15.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: kube-proxy
+    eks.amazonaws.com/component: kube-proxy
+  name: kube-proxy
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-proxy
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "beta.kubernetes.io/os"
+                operator: In
+                values:
+                - linux
+              - key: "beta.kubernetes.io/arch"
+                operator: In
+                values:
+                - arm64
+      hostNetwork: true
+      tolerations:
+      - operator: "Exists"
+      priorityClassName: system-node-critical
+      containers:
+      - name: kube-proxy
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy-arm64:v1.15.10
+        resources:
+          requests:
+            cpu: 100m
+        command:
+        - /bin/sh
+        - -c
+        - kube-proxy --v=2 --config=/var/lib/kube-proxy-config/config
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/log
+          name: varlog
+          readOnly: false
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+          readOnly: false
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /var/lib/kube-proxy/
+        - name: config
+          mountPath: /var/lib/kube-proxy-config/
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: kubeconfig
+        configMap:
+          name: kube-proxy
+      - name: config
+        configMap:
+          name: kube-proxy-config
+      serviceAccountName: kube-proxy


### PR DESCRIPTION
*Description of changes:*

- Added ARM kube proxy manifest for 1.15
- Added k8 1.15 version support in ARM nodegroup yaml
- Added m6g instance type to node group yaml

*Testing*

- Upgraded existing 1.14 cluster to 1.15 (i.e, master nodes)
- Upgraded worker nodes in two separate CF stack from 1.14 to 1.15
- Ran sample workload in worker node (based off ubuntu:bonic) image to test pod to internet connectivity 
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
