### PR TITLE
Update CNI to v1.6.2, default to Kubernetes 1.15

### DIFF
--- a/preview-programs/eks-arm-preview/README.md
+++ b/preview-programs/eks-arm-preview/README.md
@@ -32,7 +32,7 @@ Using the instructions and assets in this repository folder is governed as a pre
 The specific resources you need to run containers on EC2 ARM instances with Amazon EKS are within this repository folder. All other resources needed to successfully start and manage an EKS cluster can be found within the [EKS user guide](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html).
 
 #### Important Considerations
-* EKS currently supports the ability to run all nodes on ARM instances with Kubernetes version 1.13 and 1.14.
+* EKS currently supports the ability to run all nodes on ARM instances with Kubernetes version 1.15 (the default), 1.14 and 1.13.
 
 ## Instructions
 Follow these instructions to create a Kubernetes cluster with Amazon EKS and start a service on EC2 ARM nodes.
@@ -43,7 +43,7 @@ Follow these instructions to create a Kubernetes cluster with Amazon EKS and sta
 To create our cluster, we will use [eksctl](https://eksctl.io/), the command line tool for EKS.
 
 1. Ensure you have the latest version of [Homebrew](https://brew.sh/) installed.
-If you don't have Homebrew, you can install it with the command: `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+  If you don't have Homebrew, you can install it with the command: `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 2. Install the Weaveworks Homebrew tap: `brew tap weaveworks/tap`
 3. Install ekstctl: `brew install weaveworks/tap/eksctl`
 4. Test that your installation was successful: `eksctl --help`
@@ -52,12 +52,12 @@ If you don't have Homebrew, you can install it with the command: `/usr/bin/ruby 
 If you used the Homebrew instructions above to install eksctl on macOS, then kubectl and the aws-iam-authenticator have already been installed on your system. Otherwise, you can refer to the Amazon EKS [getting started guide prerequisites](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html#eks-prereqs).
 
 ### **Step 3.** Create Your VPC, IAM role, and Amazon EKS Cluster without worker nodes
-Create an EKS cluster without provisioning worker nodes using the following eksctl command, choosing the version of Kubernetes you would like to use:
+Create an EKS cluster without provisioning worker nodes using the following eksctl command (change the `--version` if you don't want Kubernetes 1.15):
 
 ```
 eksctl create cluster \
 --name arm-preview \
---version << Choose 1.13 or 1.14 >> \
+--version 1.15 \
 --region us-west-2 \
 --without-nodegroup
 ```
@@ -78,9 +78,9 @@ In order to support having only ARM nodes on our EKS cluster, we need to update 
 ### **Step 4.** Update the image ID used for CoreDNS
 Run one of the below commands based upon the version of Kubernetes you are using to install an updated version of `CoreDNS`:
 
-**Kubernetes 1.13**
+**Kubernetes 1.15**
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/aws/containers-roadmap/master/preview-programs/eks-arm-preview/dns-arm-1.13.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/containers-roadmap/master/preview-programs/eks-arm-preview/dns-arm-1.15.yaml
 ```
 
 **Kubernetes 1.14**
@@ -88,12 +88,17 @@ kubectl apply -f https://raw.githubusercontent.com/aws/containers-roadmap/master
 kubectl apply -f https://raw.githubusercontent.com/aws/containers-roadmap/master/preview-programs/eks-arm-preview/dns-arm-1.14.yaml
 ```
 
+**Kubernetes 1.13**
+```shell
+kubectl apply -f https://raw.githubusercontent.com/aws/containers-roadmap/master/preview-programs/eks-arm-preview/dns-arm-1.13.yaml
+```
+
 ### **Step 5.** Update the image ID used for kube-proxy
 Run the below command based upon the version of Kubernetes you are using to install an updated version of `kube-proxy`:
 
-**Kubernetes 1.13**
+**Kubernetes 1.15**
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/aws/containers-roadmap/master/preview-programs/eks-arm-preview/kube-proxy-arm-1.13.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/containers-roadmap/master/preview-programs/eks-arm-preview/kube-proxy-arm-1.15.yaml
 ```
 
 **Kubernetes 1.14**
@@ -101,8 +106,13 @@ kubectl apply -f https://raw.githubusercontent.com/aws/containers-roadmap/master
 kubectl apply -f https://raw.githubusercontent.com/aws/containers-roadmap/master/preview-programs/eks-arm-preview/kube-proxy-arm-1.14.yaml
 ```
 
+**Kubernetes 1.13**
+```shell
+kubectl apply -f https://raw.githubusercontent.com/aws/containers-roadmap/master/preview-programs/eks-arm-preview/kube-proxy-arm-1.13.yaml
+```
+
 ### **Step 6.** Deploy the ARM CNI Plugin
-Run the below command to install the AWS ARM64 CNI Plugin (this command will work for both 1.13 as well as 1.14):
+Run the below command to install the AWS ARM64 CNI Plugin (this config works on all Kubernetes versions):
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/aws/containers-roadmap/master/preview-programs/eks-arm-preview/aws-k8s-cni-arm64.yaml
@@ -141,9 +151,7 @@ region that you created your EKS cluster in.
   Cluster VPC step. (e.g. eksctl-\<cluster name\>-cluster/VPC)
   * **Subnets**: Choose the subnets that you created in Create your Amazon EKS Cluster VPC.
 
-  * **NodeImageAMI113**: The Amazon EC2 Systems Manager parameter for the 1.13 AMI image ID. You should not make any changes to this parameter; this value is ignored if you selected 1.14 for KubernetesVersion.
-
-  * **NodeImageAMI114**: The Amazon EC2 Systems Manager parameter for the 1.14 AMI image ID. You should not make any changes to this parameter; this value is ignored if you selected 1.13 for KubernetesVersion.
+  * **NodeImageAMI11X**: The Amazon EC2 Systems Manager parameter for the AMI image ID. You should not make any changes to this parameter.
 
 6. On the **Options** page, you can choose to tag your stack resources. Choose **Next**.
 7. On the **Review** page, review your information, acknowledge that the stack might create IAM resources, and then choose **Create**.

--- a/preview-programs/eks-arm-preview/aws-k8s-cni-arm64.yaml
+++ b/preview-programs/eks-arm-preview/aws-k8s-cni-arm64.yaml
@@ -8,7 +8,6 @@ rules:
       - crd.k8s.amazonaws.com
     resources:
       - "*"
-      - namespaces
     verbs:
       - "*"
   - apiGroups: [""]
@@ -76,12 +75,16 @@ spec:
                     operator: In
                     values:
                       - arm64
+                  - key: "eks.amazonaws.com/compute-type"
+                    operator: NotIn
+                    values:
+                      - fargate
       serviceAccountName: aws-node
       hostNetwork: true
       tolerations:
         - operator: Exists
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-arm64:v1.5.6
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-arm64:v1.6.2
           imagePullPolicy: Always
           ports:
             - containerPort: 61678
@@ -90,6 +93,10 @@ spec:
           env:
             - name: AWS_VPC_K8S_CNI_LOGLEVEL
               value: DEBUG
+            - name: AWS_VPC_K8S_CNI_VETHPREFIX
+              value: eni
+            - name: AWS_VPC_ENI_MTU
+              value: "9001"
             - name: MY_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -108,6 +115,8 @@ spec:
               name: log-dir
             - mountPath: /var/run/docker.sock
               name: dockersock
+            - mountPath: /var/run/dockershim.sock
+              name: dockershim
       volumes:
         - name: cni-bin-dir
           hostPath:
@@ -121,6 +130,9 @@ spec:
         - name: dockersock
           hostPath:
             path: /var/run/docker.sock
+        - name: dockershim
+          hostPath:
+            path: /var/run/dockershim.sock
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/preview-programs/eks-arm-preview/cni-metrics-helper-arm64.yaml
+++ b/preview-programs/eks-arm-preview/cni-metrics-helper-arm64.yaml
@@ -77,7 +77,7 @@ spec:
     spec:
       serviceAccountName: cni-metrics-helper
       containers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper-arm64:v1.5.6
+      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper-arm64:v1.6.2
         imagePullPolicy: Always
         name: cni-metrics-helper
         env:

--- a/preview-programs/eks-arm-preview/dns-arm-1.15.yaml
+++ b/preview-programs/eks-arm-preview/dns-arm-1.15.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/name: "CoreDNS"
+    eks.amazonaws.com/component: coredns
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+      eks.amazonaws.com/component: coredns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+        eks.amazonaws.com/component: coredns
+    spec:
+      serviceAccountName: coredns
+      priorityClassName: system-cluster-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "beta.kubernetes.io/os"
+                operator: In
+                values:
+                - linux
+              - key: "beta.kubernetes.io/arch"
+                operator: In
+                values:
+                - arm64
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - kube-dns
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      containers:
+      - name: coredns
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/coredns-arm64:v1.6.6
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+          readOnly: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+      dnsPolicy: Default
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+            - key: Corefile
+              path: Corefile


### PR DESCRIPTION
*Issue #264*

*Description of changes:*
* Bump ARM CNI to `v1.6.2` and update sample config to mount `dockershim.sock`
* Update setup example to default to 1.15
* Added a `core-dns-1.15.yaml` config (It's the same `v1.6.6` as for 1.14 right now)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
