### PR TITLE
Add workflow for stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: "Close stale issues"
+on:
+  schedule:
+    # hourly
+    - cron: "0 * * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          only-labels: "More Info Requested"
+          stale-issue-message: "Greetings! It looks like this issue hasn't been active for a while. Because it has been some time since the last update on this, and in the absence of more information, we will be closing this issue soon. Please feel free to provide a comment to prevent automatic closure, or if the issue is already closed, please feel free to open a new one."
+          stale-issue-label: "Closing Soon"
+
+          # Issue timing
+          days-before-stale: 45
+          days-before-close: 15


### PR DESCRIPTION
<!-- Please keep this note for the community -->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!-- Thank you for keeping this note for the community -->

*Description of changes:*
Initial commit of GitHub workflow that closes stale issues with a specified tag. It's for situations where a community proposal has come in but it's possibly already implemented/belongs elsewhere/inadequately described.
Configured to run in debug mode until we can verify the correctness of its behaviour.

*Links:*
- https://github.com/actions/stale


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
